### PR TITLE
Fix Get-User to select a unique name and suppress errors

### DIFF
--- a/HTMLReport.ps1
+++ b/HTMLReport.ps1
@@ -550,11 +550,11 @@ Foreach ($User in $AllUsers)
 	$UPN = $User.UserPrincipalName
 	$UserLicenses = ($NewObject02 | Select-Object -ExpandProperty Licenses) -join ", "
 	$Enabled = $User.AccountEnabled
-	$ResetPW = Get-User $User.DisplayName | Select-Object -ExpandProperty ResetPasswordOnNextLogon 
+	$ResetPW = Get-User $User.UserPrincipalName | Select-Object -ExpandProperty ResetPasswordOnNextLogon
 	
     If ($IncludeLastLogonTimestamp -eq $True)
     {
-    $LastLogon = Get-Mailbox $User.DisplayName | Get-MailboxStatistics -ErrorAction SilentlyContinue  | Select-Object -ExpandProperty LastLogonTime -ErrorAction SilentlyContinue
+    $LastLogon = Get-Mailbox $User.DisplayName -ErrorAction SilentlyContinue | Get-MailboxStatistics -ErrorAction SilentlyContinue  | Select-Object -ExpandProperty LastLogonTime -ErrorAction SilentlyContinue
 	    $obj = [PSCustomObject]@{
 		    'Name'				                   = $Name
 		    'UserPrincipalName'	                   = $UPN


### PR DESCRIPTION
Get-User should not filter on Display Name as it may not be unique, change to UPN. All users don't necessarily have a mailbox so suppress situations where they don't